### PR TITLE
Unpinned zhmcclient and accomodated verify_cert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ paramiko>=1.16
 PyYAML>=3.11
 jsonschema>=2.5.1
 requests>=2.10.0
-zhmcclient==0.30.2
+zhmcclient>=0.31.0

--- a/tessia/baselib/hypervisors/hmc/hmc.py
+++ b/tessia/baselib/hypervisors/hmc/hmc.py
@@ -917,7 +917,7 @@ class HypervisorHmc(HypervisorBase):
 
         rt_config = zhmcclient.RetryTimeoutConfig(connect_timeout=timeout)
         session = zhmcclient.Session(
-            self.host_name, self.user, self.passwd,
+            self.host_name, self.user, self.passwd, verify_cert=False,
             retry_timeout_config=rt_config,
             port=self.parameters.get('port', zhmcclient.DEFAULT_HMC_PORT))
         try:


### PR DESCRIPTION
Details:

* Other projects using tessia-baselib have a version conflict due to the pinning of the zhmcclient package to version 0.30.2. The reason for the pinning was that that was the last version that did not support certificate validation yet. zhmcclient 0.31.0 introduced a verify_cert parameter for zhmcclient.Session() with a default of True.

  This change unpins the zhmcclient version and defines its minimum to 0.31.0, and specifies verify_cert=False in its Session() call, so that again no certificate is used.